### PR TITLE
Make ParameterDiff detect changes to fx the Type of a PathParameter

### DIFF
--- a/src/main/java/com/deepoove/swagger/diff/compare/ListDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/ListDiff.java
@@ -3,12 +3,15 @@ package com.deepoove.swagger.diff.compare;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import com.google.common.collect.Lists;
+
 /**
  * compare two Lists
- * 
+ *
  * @author Sayi
  * @version
  */
@@ -27,13 +30,14 @@ public class ListDiff<K> {
     }
 
     /**
-     * 
+     *
      * @param left
      * @param right
      * @param biFunc
      *            if right List contains left element
      * @return
      */
+    @SuppressWarnings("unchecked")
     public static <K> ListDiff<K> diff(List<K> left, List<K> right,
             BiFunction<List<K>, K, K> biFunc) {
         ListDiff<K> instance = new ListDiff<>();
@@ -52,7 +56,14 @@ public class ListDiff<K> {
         for (K ele : left) {
             K rightEle = biFunc.apply(right, ele);
             if (null != rightEle) {
-                instance.increased.remove(ele);
+                ListIterator<K> listIterator = instance.increased.listIterator();
+                while(listIterator.hasNext()){
+                    K k = listIterator.next();
+                    if (biFunc.apply(Lists.newArrayList(k), ele)!=null) {
+                        listIterator.remove();
+                        break;
+                    }
+                }
                 instance.shared.put(ele, rightEle);
             } else {
                 instance.missing.add(ele);

--- a/src/main/java/com/deepoove/swagger/diff/compare/ParameterDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/ParameterDiff.java
@@ -7,15 +7,20 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 import com.deepoove.swagger.diff.model.ChangedParameter;
+import com.deepoove.swagger.diff.model.ElProperty;
+import com.google.common.collect.Lists;
 
 import io.swagger.models.Model;
 import io.swagger.models.RefModel;
+import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 
 /**
  * compare two parameter
- * 
+ *
  * @author Sayi
  * @version
  */
@@ -55,28 +60,35 @@ public class ParameterDiff {
         this.increased.addAll(paramDiff.getIncreased());
         this.missing.addAll(paramDiff.getMissing());
         Map<Parameter, Parameter> shared = paramDiff.getShared();
-        
         shared.forEach((leftPara, rightPara) -> {
             ChangedParameter changedParameter = new ChangedParameter();
             changedParameter.setLeftParameter(leftPara);
             changedParameter.setRightParameter(rightPara);
-
             if (leftPara instanceof BodyParameter && rightPara instanceof BodyParameter) {
                 BodyParameter leftBodyPara = (BodyParameter) leftPara;
                 Model leftSchema = leftBodyPara.getSchema();
                 BodyParameter rightBodyPara = (BodyParameter) rightPara;
-                Model rightSchema = rightBodyPara.getSchema(); 
+                Model rightSchema = rightBodyPara.getSchema();
                 if (leftSchema instanceof RefModel && rightSchema instanceof RefModel) {
                     String leftRef = ((RefModel) leftSchema).getSimpleRef();
                     String rightRef = ((RefModel) rightSchema).getSimpleRef();
                     Model leftModel = oldDedinitions.get(leftRef);
                     Model rightModel = newDedinitions.get(rightRef);
-                    
                     ModelDiff diff = ModelDiff.buildWithDefinition(oldDedinitions, newDedinitions)
                             .diff(leftModel, rightModel, leftPara.getName());
                     changedParameter.setIncreased(diff.getIncreased());
                     changedParameter.setMissing(diff.getMissing());
                     changedParameter.setChanged(diff.getChanged());
+                }
+            }
+
+            //Let's handle the case where the new API has fx changed the type of PathParameter from being of type String to type integer
+            if (leftPara instanceof AbstractSerializableParameter && rightPara instanceof AbstractSerializableParameter) {
+                if (!leftPara.equals(rightPara)) {
+                    ElProperty elProperty = new ElProperty();
+                    elProperty.setEl(rightPara.getName());
+                    elProperty.setProperty(mapToProperty(rightPara));
+                    changedParameter.setChanged(Lists.newArrayList(elProperty));
                 }
             }
 
@@ -99,6 +111,17 @@ public class ParameterDiff {
         });
 
         return this;
+    }
+
+    private Property mapToProperty(Parameter rightPara) {
+        Property prop = new StringProperty();
+        prop.setAccess(rightPara.getAccess());
+        prop.setAllowEmptyValue(rightPara.getAllowEmptyValue());
+        prop.setDescription(rightPara.getDescription());
+        prop.setName(rightPara.getName());
+        prop.setReadOnly(rightPara.isReadOnly());
+        prop.setRequired(rightPara.getRequired());
+        return prop;
     }
 
     public List<Parameter> getIncreased() {

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -710,9 +710,10 @@
           {
             "name": "username",
             "in": "path",
-            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "description": "The name that needs to be fetched. Use user1 for testing. edited",
             "required": true,
-            "type": "string"
+            "type": "integer",
+            "format": "int32"
           }
         ],
         "responses": {


### PR DESCRIPTION
Minor changes to ParameterDiff and supporting class ListDiff to make the swagger-diff tool report when a parameter has been changed.
Example: Say a path parameter changes from type String to integer. This breaks backwards compatibility. 

ListDiff change:
The ListDiff class previously attempted to remove elements from the 'increased' list using a call to equals. But since the two Parameters are not equal the element was not removed from the list (which it ought to be since the parameter is not new, only changed.

ParameterDiff change:
Previously the logic only handled BodyParameters.