### PR TITLE
add JsonRender

### DIFF
--- a/src/main/java/com/deepoove/swagger/diff/cli/CLI.java
+++ b/src/main/java/com/deepoove/swagger/diff/cli/CLI.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.deepoove.swagger.diff.SwaggerDiff;
 import com.deepoove.swagger.diff.output.HtmlRender;
+import com.deepoove.swagger.diff.output.JsonRender;
 import com.deepoove.swagger.diff.output.MarkdownRender;
 import com.deepoove.swagger.diff.output.Render;
 
@@ -12,34 +13,35 @@ import com.deepoove.swagger.diff.output.Render;
  *  -new http://www.petstore.com/swagger_new.json \n
  *  -v 2.0 \n
  *  -output-mode markdown \n
- *  
+ *
  * @author Sayi
- * @version 
+ * @version
  */
 public class CLI {
-    
+
     private static final String OUTPUT_MODE_MARKDOWN = "markdown";
-    
+    private static final String OUTPUT_MODE_JSON = "json";
+
     @Parameter(names = "-old", description = "old api-doc location:Json file path or Http url", required = true, order = 0)
     private String oldSpec;
-    
+
     @Parameter(names = "-new", description = "new api-doc location:Json file path or Http url", required = true, order = 1)
     private String newSpec;
-    
+
     @Parameter(names = "-v", description = "swagger version:1.0 or 2.0", validateWith=  RegexValidator.class, order = 2)
     @Regex("(2\\.0|1\\.0)")
     private String version = SwaggerDiff.SWAGGER_VERSION_V2;
-    
-    @Parameter(names = "-output-mode", description = "render mode: markdown or html", validateWith=  RegexValidator.class, order = 3)
-    @Regex("(markdown|html)")
+
+    @Parameter(names = "-output-mode", description = "render mode: markdown, html or json", validateWith = RegexValidator.class, order = 3)
+    @Regex("(markdown|html|json)")
     private String outputMode = OUTPUT_MODE_MARKDOWN;
-    
+
     @Parameter(names = "--help", help = true, order = 5)
     private boolean help;
-    
+
     @Parameter(names = "--version", description = "swagger-diff tool version", help = true, order = 6)
     private boolean v;
-    
+
     public static void main(String[] args) {
         CLI cli = new CLI();
         JCommander jCommander = JCommander.newBuilder()
@@ -59,16 +61,20 @@ public class CLI {
             JCommander.getConsole().println("1.2.1");
             return;
         }
-        
+
         SwaggerDiff diff = SwaggerDiff.SWAGGER_VERSION_V2.equals(version)
                 ? SwaggerDiff.compareV2(oldSpec, newSpec) : SwaggerDiff.compareV1(oldSpec, newSpec);
-        
+
         String render = getRender(outputMode).render(diff);
         JCommander.getConsole().println(render);
     }
 
     private Render getRender(String outputMode) {
-        if (OUTPUT_MODE_MARKDOWN.equals(outputMode)) return new MarkdownRender();
+        if (OUTPUT_MODE_MARKDOWN.equals(outputMode)) {
+            return new MarkdownRender();
+        } else if (OUTPUT_MODE_JSON.equals(outputMode)) {
+            return new JsonRender();
+        }
         return new HtmlRender("Changelog", "http://deepoove.com/swagger-diff/stylesheets/demo.css");
     }
 

--- a/src/main/java/com/deepoove/swagger/diff/output/JsonRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/JsonRender.java
@@ -1,0 +1,12 @@
+package com.deepoove.swagger.diff.output;
+
+import com.alibaba.fastjson.JSON;
+import com.deepoove.swagger.diff.SwaggerDiff;
+
+public class JsonRender implements Render {
+
+    @Override
+    public String render(SwaggerDiff diff) {
+        return JSON.toJSONString(diff);
+    }
+}

--- a/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
@@ -1,20 +1,20 @@
 package com.deepoove.swagger.test;
 
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.deepoove.swagger.diff.SwaggerDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.deepoove.swagger.diff.output.HtmlRender;
+import com.deepoove.swagger.diff.output.JsonRender;
 import com.deepoove.swagger.diff.output.MarkdownRender;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 public class SwaggerDiffTest {
 
@@ -128,6 +128,23 @@ public class SwaggerDiffTest {
 		}
 
 	}
+
+
+	@Test
+	public void testJsonRender() {
+		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2);
+		String render = new JsonRender().render(diff);
+		try {
+			FileWriter fw = new FileWriter(
+					"testDiff.json");
+			fw.write(render);
+			fw.close();
+
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
 
 	private void assertEqual(SwaggerDiff diff) {
 		List<Endpoint> newEndpoints = diff.getNewEndpoints();


### PR DESCRIPTION
Hi, @Sayi 

I use swagger-diff as console application and I'd love to have a way to analyze results of swagger-diff, for instance, for checking backward compatabiluty. But unfortunately it is imposible because we have only html and markdown renders. 
I have added json render. So we are able to work with simple data structure