### PR TITLE
Fix comparing submodels to take into account the correct property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ hs_err_pid*
 swagger-diff.iml
 testDiff.html 
 testDiff.md
+testDiff.json
 testDeprecatedApi.html
 testNewApi.html
 

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,27 @@
 				<artifactId>coveralls-maven-plugin</artifactId>
 				<version>4.3.0</version>
 			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>com.deepoove.swagger.diff.cli.CLI</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/com/deepoove/swagger/diff/compare/ModelDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/ModelDiff.java
@@ -85,7 +85,7 @@ public class ModelDiff {
             Property left = leftProperties.get(key);
             Property right = rightProperties.get(key);
             Model leftSubModel = findModel(left, oldDedinitions);
-            Model rightSubModel = findModel(left, newDedinitions);
+            Model rightSubModel = findModel(right, newDedinitions);
             if (leftSubModel != null || rightSubModel != null) {
                 diff(leftSubModel, rightSubModel, buildElString(parentEl, key),
                         copyAndAdd(visited, leftModel, rightModel));

--- a/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
@@ -2,6 +2,8 @@ package com.deepoove.swagger.diff.model;
 
 import io.swagger.models.properties.Property;
 
+import java.util.List;
+
 /**
  * property with expression Language grammar
  * 
@@ -15,9 +17,11 @@ public class ElProperty {
     private Property property;
 
     // optional change metadata
-    private boolean isTypeChange;
-    private boolean newEnums;
-    private boolean removedEnums;
+    private String newTypeChange;
+    private List<String> newEnums;
+    private List<String> removedEnums;
+
+    private String metadataChanged;
 
     public Property getProperty() {
         return property;
@@ -35,27 +39,35 @@ public class ElProperty {
         this.el = el;
     }
 
-    public boolean isTypeChange() {
-        return isTypeChange;
+    public String getNewTypeChange() {
+        return newTypeChange;
     }
 
-    public void setTypeChange(boolean typeChange) {
-        isTypeChange = typeChange;
+    public void setNewTypeChange(String typeChange) {
+        newTypeChange = newTypeChange;
     }
 
-    public boolean isNewEnums() {
+    public List<String> getNewEnums() {
         return newEnums;
     }
 
-    public void setNewEnums(boolean newEnums) {
+    public void setNewEnums(List<String> newEnums) {
         this.newEnums = newEnums;
     }
 
-    public boolean isRemovedEnums() {
+    public void metadataChanged(String changes) {
+        this.metadataChanged = changes;
+    }
+
+    public String metadataChanged() {
+        return this.metadataChanged;
+    }
+
+    public List<String> getRemovedEnums() {
         return removedEnums;
     }
 
-    public void setRemovedEnums(boolean removedEnums) {
+    public void setRemovedEnums(List<String> removedEnums) {
         this.removedEnums = removedEnums;
     }
 }

--- a/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
@@ -2,15 +2,18 @@ package com.deepoove.swagger.diff.output;
 
 import com.deepoove.swagger.diff.SwaggerDiff;
 import com.deepoove.swagger.diff.model.*;
+import com.google.common.collect.Collections2;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.Property;
 import j2html.tags.ContainerTag;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import static j2html.TagCreator.*;
 
@@ -169,15 +172,27 @@ public class HtmlRender implements Render {
     private ContainerTag li_changedProp(ElProperty prop) {
         List<String> changeDetails = new ArrayList<>();
         String changeDetailsHeading = "";
-        if (prop.isTypeChange()) {
-            changeDetails.add("Data Type");
+        if (!StringUtils.isBlank(prop.getNewTypeChange())) {
+            changeDetails.add(String.format("Changed data type to %s", prop.getNewTypeChange()));
         }
-        if (prop.isNewEnums()) {
-            changeDetails.add("Added Enum");
+        if (prop.getNewEnums() != null && !prop.getNewEnums().isEmpty()) {
+            changeDetails.add(String.format("Added enum value %s", prop.getNewEnums()
+              .stream()
+              .map(val -> String.format("'%s'", val))
+              .collect(Collectors.joining(", "))
+            ));
         }
-        if (prop.isRemovedEnums()) {
-            changeDetails.add("Removed Enum");
+        if (prop.getRemovedEnums() != null && !prop.getRemovedEnums().isEmpty()) {
+            changeDetails.add(String.format("Removed enum value %s", prop.getRemovedEnums()
+              .stream()
+              .map(val -> String.format("'%s'", val))
+              .collect(Collectors.joining(", "))
+            ));
         }
+        if(!StringUtils.isBlank(prop.metadataChanged())) {
+            changeDetails.add(prop.metadataChanged());
+        }
+
         if (! changeDetails.isEmpty()) {
             changeDetailsHeading = " (" + String.join(", ", changeDetails) + ")";
         }

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -10,6 +10,7 @@ import com.deepoove.swagger.diff.model.*;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.Property;
+import org.apache.commons.lang3.StringUtils;
 
 public class MarkdownRender implements Render {
 
@@ -63,7 +64,7 @@ public class MarkdownRender implements Render {
     private String li_newEndpoint(String method, String path, String desc) {
         StringBuffer sb = new StringBuffer();
         sb.append(LI).append(CODE).append(method).append(CODE)
-                .append(" " + path).append(" " + desc + "\n");
+                .append(" " + path).append(" " + StringUtils.trimToEmpty(desc) + "\n");
         return sb.toString();
     }
 
@@ -108,7 +109,7 @@ public class MarkdownRender implements Render {
                             .append(ul_consume(changedOperation));
                 }
                 sb.append(CODE).append(method).append(CODE)
-                        .append(" " + pathUrl).append(" " + desc + "  \n")
+                        .append(" " + pathUrl).append(" " + StringUtils.trimToEmpty(desc) + "  \n")
                         .append(ul_detail);
             }
         }

--- a/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.parameters.BodyParameter;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -275,14 +276,14 @@ public class SwaggerDiffTest {
 		Assert.assertEquals(2, postChgProps.size());
 		ElProperty orderIdProp = postChgProps.stream().filter(cp -> {
 			return cp.getEl().equalsIgnoreCase("body.id");}).findFirst().get();
-		Assert.assertTrue(orderIdProp.isTypeChange());
-		Assert.assertFalse(orderIdProp.isNewEnums());
-		Assert.assertFalse(orderIdProp.isRemovedEnums());
+		Assert.assertTrue(StringUtils.isBlank(orderIdProp.getNewTypeChange()));
+		Assert.assertNull(orderIdProp.getNewEnums());
+		Assert.assertNull(orderIdProp.getRemovedEnums());
 		ElProperty statusProp = postChgProps.stream().filter(cp -> {
 			return cp.getEl().equalsIgnoreCase("body.status");}).findFirst().get();
-		Assert.assertFalse(statusProp.isTypeChange());
-		Assert.assertTrue(statusProp.isNewEnums());
-		Assert.assertTrue(statusProp.isRemovedEnums());
+		Assert.assertTrue(StringUtils.isBlank(orderIdProp.getNewTypeChange()));
+		Assert.assertNotNull(statusProp.getNewEnums());
+		Assert.assertNotNull(statusProp.getRemovedEnums());
 
 
 		Assert.assertTrue("Expecting changed endpoint " + getOrder, changedEndpointMap.containsKey(getOrder));
@@ -293,14 +294,14 @@ public class SwaggerDiffTest {
 
 		orderIdProp = getChgProps.stream().filter(cp -> {
 			return cp.getEl().equalsIgnoreCase("id");}).findFirst().get();
-		Assert.assertTrue(orderIdProp.isTypeChange());
-		Assert.assertFalse(orderIdProp.isNewEnums());
-		Assert.assertFalse(orderIdProp.isRemovedEnums());
+		Assert.assertTrue(StringUtils.isBlank(orderIdProp.getNewTypeChange()));
+		Assert.assertNull(orderIdProp.getNewEnums());
+		Assert.assertNull(orderIdProp.getRemovedEnums());
 		statusProp = getChgProps.stream().filter(cp -> {
 			return cp.getEl().equalsIgnoreCase("status");}).findFirst().get();
-		Assert.assertFalse(statusProp.isTypeChange());
-		Assert.assertTrue(statusProp.isNewEnums());
-		Assert.assertTrue(statusProp.isRemovedEnums());
+		Assert.assertTrue(StringUtils.isBlank(statusProp.getNewTypeChange()));
+		Assert.assertNotNull(statusProp.getNewEnums());
+		Assert.assertNotNull(statusProp.getRemovedEnums());
 	}
 
 	private void assertEqual(SwaggerDiff diff) {


### PR DESCRIPTION
I run into the problem that when swagger model is renamed, generated html file shows all endpoint response properties as removed. The pr fixed this issue.